### PR TITLE
Add 'craft_guide' as optional dependency

### DIFF
--- a/depends.txt
+++ b/depends.txt
@@ -2,3 +2,4 @@ default
 stairs
 moreblocks?
 intllib?
+craft_guide?


### PR DESCRIPTION
For optional compatibility with [cornernote's craft_guide](http://cornernote.github.io/minetest-craft_guide/) mod.