### PR TITLE
Allow quartz to be used in circular saws.

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -12,9 +12,10 @@ License: MIT (see LICENSE.txt)
 Dependencies:
 default (found in minetest_game)
 stairs (found in minetest_game)
-moreblocks (optional, for stairsplus support)
+intllib (optional, for translations)
+moreblocks or stairsplus (optional, for stairsplus support)
 
-Please report bugs at the github issue tracker:
+Please report bugs at the GitHub issue tracker:
 https://github.com/minetest-mods/quartz/issues/
 
 Crafting:
@@ -80,3 +81,6 @@ x|x|x
 x|c|x
 -----
 x|x|x
+
+If you have stairsplus (or moreblocks) installed, you will be able to use
+circular saws to cut quartz blocks.

--- a/depends.txt
+++ b/depends.txt
@@ -1,4 +1,5 @@
 default
 stairs
-moreblocks?
 intllib?
+moreblocks?
+stairsplus?

--- a/description.txt
+++ b/description.txt
@@ -1,1 +1,1 @@
-Adds quartz ore and some decorative quartz blocks
+Adds quartz ore and some decorative quartz blocks.

--- a/init.lua
+++ b/init.lua
@@ -62,7 +62,8 @@ minetest.register_node("quartz:chiseled", {
 minetest.register_node("quartz:pillar", {
 	description = S("Quartz Pillar"),
 	paramtype2 = "facedir",
-	tiles = {"quartz_pillar_top.png", "quartz_pillar_top.png", "quartz_pillar_side.png"},
+	tiles = {"quartz_pillar_top.png", "quartz_pillar_top.png",
+		"quartz_pillar_side.png"},
 	groups = {cracky=3, oddly_breakable_by_hand=1},
 	sounds = default.node_sound_glass_defaults(),
 	on_place = minetest.rotate_node
@@ -78,7 +79,8 @@ stairs.register_stair_and_slab("quartzblock", "quartz:block",
 
 stairs.register_stair_and_slab("quartzstair", "quartz:pillar",
 		{cracky=3, oddly_breakable_by_hand=1},
-		{"quartz_pillar_top.png", "quartz_pillar_top.png", "quartz_pillar_side.png"},
+		{"quartz_pillar_top.png", "quartz_pillar_top.png",
+			"quartz_pillar_side.png"},
 		S("Quartz Pillar stair"),
 		S("Quartz Pillar slab"),
 		default.node_sound_glass_defaults())
@@ -174,7 +176,8 @@ if minetest.global_exists("stairsplus") then
 
 	stairsplus:register_all("quartz", "pillar", "quartz:pillar", {
 		description = "Quartz Pillar",
-		tiles  = {"quartz_pillar_top.png", "quartz_pillar_top.png", "quartz_pillar_side.png"},
+		tiles  = {"quartz_pillar_top.png", "quartz_pillar_top.png",
+			"quartz_pillar_side.png"},
 		groups = {cracky=3},
 		sounds = default.node_sound_glass_defaults()
 	})
@@ -188,11 +191,14 @@ if settings:get_bool("ENABLE_HORIZONTAL_PILLAR") then
 	-- Quartz Pillar (horizontal)
 	minetest.register_node("quartz:pillar_horizontal", {
 			description = "Quartz Pillar Horizontal",
-			tiles = {"quartz_pillar_side.png", "quartz_pillar_side.png", "quartz_pillar_side.png^[transformR90",
-			"quartz_pillar_side.png^[transformR90", "quartz_pillar_top.png", "quartz_pillar_top.png"},
+			tiles = {"quartz_pillar_side.png", "quartz_pillar_side.png",
+				"quartz_pillar_side.png^[transformR90",
+				"quartz_pillar_side.png^[transformR90", "quartz_pillar_top.png",
+				"quartz_pillar_top.png"},
 			paramtype2 = "facedir",
 			drop = 'quartz:pillar',
-			groups = {cracky=3, oddly_breakable_by_hand=1, not_in_creative_inventory=1},
+			groups = {cracky=3, oddly_breakable_by_hand=1,
+				not_in_creative_inventory=1},
 			sounds = default.node_sound_glass_defaults(),
 	})
 end

--- a/init.lua
+++ b/init.lua
@@ -157,34 +157,27 @@ minetest.register_abm({
 -- Compatibility with stairsplus
 --
 
-if minetest.get_modpath("moreblocks") and settings:get_bool("ENABLE_STAIRSPLUS") then
-	register_stair_slab_panel_micro("quartz", "block", "quartz:block",
-		{cracky=3},
-		{"quartz_block.png"},
-		"Quartz Block",
-		"block",
-		0
-	)
+if minetest.global_exists("stairsplus") then
+	stairsplus:register_all("quartz", "block", "quartz:block", {
+		description = "Quartz Block",
+		tiles  = {"quartz_block.png"},
+		groups = {cracky=3},
+		sounds = default.node_sound_glass_defaults()
+	})
 
-	register_stair_slab_panel_micro("quartz", "chiseled", "quartz:chiseled",
-		{cracky=3},
-		{"quartz_chiseled.png"},
-		"Chiseled Quartz",
-		"chiseled",
-		0
-	)
+	stairsplus:register_all("quartz", "chiseled", "quartz:chiseled", {
+		description = "Chiseled Quartz",
+		tiles  = {"quartz_chiseled.png"},
+		groups = {cracky=3},
+		sounds = default.node_sound_glass_defaults()
+	})
 
-	register_stair_slab_panel_micro("quartz", "pillar", "quartz:pillar",
-		{cracky=3},
-		{"quartz_pillar_top.png", "quartz_pillar_top.png", "quartz_pillar_side.png"},
-		"Quartz Pillar",
-		"pillar",
-		0
-	)
-
-	table.insert(circular_saw.known_stairs, "quartz:block")
-	table.insert(circular_saw.known_stairs, "quartz:chiseled")
-	table.insert(circular_saw.known_stairs, "quartz:pillar")
+	stairsplus:register_all("quartz", "pillar", "quartz:pillar", {
+		description = "Quartz Pillar",
+		tiles  = {"quartz_pillar_top.png", "quartz_pillar_top.png", "quartz_pillar_side.png"},
+		groups = {cracky=3},
+		sounds = default.node_sound_glass_defaults()
+	})
 end
 
 --

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,4 @@
-name = quartz
+name             = quartz
+description      = Adds quartz ore and some decorative quartz blocks.
+depends          = default,stairs
+optional_depends = moreblocks,intllib

--- a/mod.conf
+++ b/mod.conf
@@ -1,4 +1,4 @@
 name             = quartz
 description      = Adds quartz ore and some decorative quartz blocks.
 depends          = default,stairs
-optional_depends = moreblocks,intllib
+optional_depends = intllib,moreblocks,stairsplus


### PR DESCRIPTION
Allow quartz to be used in circular saws, fix indenting issues and make `mod.conf` 5.0-friendly.