### PR TITLE
amend load print

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -190,3 +190,6 @@ if settings:get_bool("ENABLE_HORIZONTAL_PILLAR") then
 			sounds = default.node_sound_glass_defaults(),
 	})
 end
+
+-- print to log after mod was loaded successfully
+print ("[MOD] Quartz loaded")


### PR DESCRIPTION
Add a final **print to log** at the end of `init.lua` to indicate the mod was loaded successfully. This idea was derived from other mods which are specifically aimed at MT servers.

This could be useful not only for player support (e.g. in the MT forum) but would certainly be useful for MT server admins using the CLI and reading their server logs.